### PR TITLE
Make the random characters follow a uniform distribution

### DIFF
--- a/lib/password-generator.js
+++ b/lib/password-generator.js
@@ -42,7 +42,7 @@
         pattern = consonant;
       }
     }
-    n = (Math.floor(Math.random() * 100) % 94) + 33;
+    n = Math.floor(Math.random() * 94) + 33;
     char = String.fromCharCode(n);
     if (memorable) {
       char = char.toLowerCase();


### PR DESCRIPTION
The original kind of random selection results in a needless higher probability of the first 6 characters in this range.

See: http://jsfiddle.net/22AdT/2/

Even after this change, the allocation of characters for `memorable` passwords is still not even, since all of the letters will have double the probability of other characters.
