### PR TITLE
fixing == according to JavaScript Best Practices

### DIFF
--- a/dist/password-generator.js
+++ b/dist/password-generator.js
@@ -20,16 +20,16 @@
 
   password = function (length, memorable, pattern, prefix) {
     var char = "", n, i, validChars = [];
-    if (length == null) {
+    if (length === null || typeof(length) === "undefined") {
       length = 10;
     }
-    if (memorable == null) {
+    if (memorable === null || typeof(memorable) === "undefined") {
       memorable = true;
     }
-    if (pattern == null) {
+    if (pattern === null || typeof(pattern) === "undefined") {
       pattern = /\w/;
     }
-    if (prefix == null) {
+    if (prefix === null || typeof(prefix) === "undefined") {
       prefix = '';
     }
 

--- a/lib/password-generator.js
+++ b/lib/password-generator.js
@@ -20,16 +20,16 @@
 
   password = function (length, memorable, pattern, prefix) {
     var char = "", n, i, validChars = [];
-    if (length == null) {
+    if (length === null || typeof(length) === "undefined") {
       length = 10;
     }
-    if (memorable == null) {
+    if (memorable === null || typeof(memorable) === "undefined") {
       memorable = true;
     }
-    if (pattern == null) {
+    if (pattern === null || typeof(pattern) === "undefined") {
       pattern = /\w/;
     }
-    if (prefix == null) {
+    if (prefix === null || typeof(prefix) === "undefined") {
       prefix = '';
     }
 


### PR DESCRIPTION
JSLint tools are complaining about those "==" lines.
For a basic guide why to avoid them check https://www.w3schools.com/js/js_best_practices.asp

Please accept my merge request.